### PR TITLE
fix x-token header

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -39,7 +39,7 @@ const authLink = new ApolloLink((operation, forward) => {
   operation.setContext(({ headers = {} }) => ({
     headers: {
       ...headers,
-      'x-token': `${localStorage.getItem('token')}`,
+      'x-token': localStorage.getItem('token'),
     },
   }));
 


### PR DESCRIPTION
Fixes issue where if you are not logged in and there is no token, the server will read an empty token as the string `'null'`. This causes errors to be thrown. Taking the `localStorage` token out of a template string fixes this issue. If there is no token (with no actively logged-in user) it will be an empty string, which line 22 of `server/src/index.js` interprets correctly.